### PR TITLE
JOH-25: Update the scraper to handle OpenAI token limits and use gpt-4-turbo

### DIFF
--- a/main.py
+++ b/main.py
@@ -48,5 +48,5 @@ def extract_info_with_chatgpt(html_content_list):
                 {'role': 'user', 'content': html_content}
             ]
         )
-        extracted_info += response['choices'][0]['message']['content']
+        extracted_info += response['choices'][0]['message']['content'] + '\n-----\n'
     return extracted_info

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,7 +1,7 @@
 import unittest
 from unittest.mock import Mock
 from fastapi.testclient import TestClient
-from main import app, UrlInput, scrape_url, extract_info_with_chatgpt
+from main import app, UrlInput, scrape_url, extract_info_with_chatgpt, split_html_content
 import os
 
 
@@ -32,8 +32,13 @@ class TestMain(unittest.TestCase):
         scrape_url = Mock(return_value=mock_html_content)
         self.assertEqual(scrape_url(mock_url), mock_html_content)
 
+    def test_split_html_content(self):
+        mock_html_content = 'a' * 800000
+        expected_result = ['a' * 400000, 'a' * 400000]
+        self.assertEqual(split_html_content(mock_html_content), expected_result)
+
     def test_extract_info_with_chatgpt(self):
-        mock_html_content = '<html><body>Mocked HTML content</body></html>'
+        mock_html_content_list = ['<html><body>Mocked HTML content</body></html>', '<html><body>Another mocked HTML content</body></html>']
         mock_extracted_info = 'Mocked extracted info'
         extract_info_with_chatgpt = Mock(return_value=mock_extracted_info)
-        self.assertEqual(extract_info_with_chatgpt(mock_html_content), mock_extracted_info)
+        self.assertEqual(extract_info_with_chatgpt(mock_html_content_list), mock_extracted_info)


### PR DESCRIPTION
This PR addresses ticket JOH-25. It updates the `scrape_url` and `extract_info_with_chatgpt` functions in `main.py` to handle OpenAI token limits by splitting the returned HTML into chunks, each not exceeding 400,000 characters. It also updates the model used by the OpenAI API to `gpt-4-turbo`.

### Test Plan

pytest