### PR TITLE
JOH-28: Remove html_content from response

### DIFF
--- a/main.py
+++ b/main.py
@@ -21,7 +21,7 @@ def input_url(url_input: UrlInput):
     url = url_input.url
     html_content = scrape_url(url)
     extracted_info = extract_info_with_chatgpt(html_content)
-    return {'message': 'URL received', 'url': url, 'html_content': html_content, 'extracted_info': extracted_info}
+    return {'message': 'URL received', 'url': url, 'extracted_info': extracted_info}
 
 
 def scrape_url(url):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -18,9 +18,8 @@ class TestMain(unittest.TestCase):
 
     def test_input_url(self):
         mock_url = 'http://mocked.url'
-        mock_html_content = '<html><body>Mocked HTML content</body></html>'
         mock_extracted_info = 'Mocked extracted info'
-        mock_response = {'message': 'URL received', 'url': mock_url, 'html_content': mock_html_content, 'extracted_info': mock_extracted_info}
+        mock_response = {'message': 'URL received', 'url': mock_url, 'extracted_info': mock_extracted_info}
         self.client.post = Mock(return_value=Mock(status_code=200, json=lambda: mock_response))
         response = self.client.post('/input_url', json={'url': mock_url})
         self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
This PR addresses the task of removing the `html_content` from the response of the `input_url` endpoint. The `html_content` was previously included in the response for debugging purposes, but it is no longer needed in the production environment. The changes include the modification of the `input_url` function in `main.py` and the corresponding unit test in `tests/test_main.py`.

### Test Plan

pytest