### PR TITLE
JOH-29: Add index.html with form and URL input

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,4 +1,5 @@
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.templating import Jinja2Templates
 from pydantic import BaseModel, HttpUrl
 import requests
 import openai
@@ -6,14 +7,15 @@ import os
 
 app = FastAPI()
 
+templates = Jinja2Templates(directory="templates")
 
 class UrlInput(BaseModel):
     url: HttpUrl
 
 
 @app.get('/')
-def hello_world():
-    return {'message': 'Hello, World!'}
+def hello_world(request: Request):
+    return templates.TemplateResponse('index.html', {'request': request})
 
 
 @app.post('/input_url')

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ httpx==0.18.2
 pytest-mock==3.6.1
 requests
 openai
+jinja2==3.0.3

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>URL Review Extractor</title>
+</head>
+<body>
+<h1>URL Review Extractor</h1>
+<form action="/input_url" method="post">
+<label for="url">URL:</label><br>
+<input type="text" id="url" name="url"><br>
+<input type="submit" value="Submit">
+</form>
+</body>
+</html>

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -10,11 +10,11 @@ class TestMain(unittest.TestCase):
         self.client = TestClient(app)
 
     def test_hello_world(self):
-        mock_response = {'message': 'Hello, Mocked World!'}
-        self.client.get = Mock(return_value=Mock(status_code=200, json=lambda: mock_response))
         response = self.client.get('/')
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), mock_response)
+        self.assertEqual(response.template.name, 'index.html')
+        self.assertIsInstance(response.context, dict)
+        self.assertIn('request', response.context)
 
     def test_input_url(self):
         mock_url = 'http://mocked.url'


### PR DESCRIPTION
This PR adds a simple index.html file with a form and an input field for the URL. The form submits the URL to the '/input_url' endpoint of the FastAPI application. It also includes the necessary changes in the main.py file to serve the HTML file and updates the requirements.txt file to include the Jinja2 package. The tests have been updated to reflect these changes.

### Test Plan

pytest