### PR TITLE
JOH-31: Render response in HTML

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -11,6 +11,8 @@
 <input type="submit" value="Submit">
 </form>
 
+<div id="response"></div>
+
 <script>
 document.getElementById('urlForm').addEventListener('submit', function(event) {
   event.preventDefault();
@@ -21,7 +23,9 @@ document.getElementById('urlForm').addEventListener('submit', function(event) {
       'Content-Type': 'application/json'
     },
     body: JSON.stringify({ url: url })
-  }).then(response => response.json()).then(data => console.log(data));
+  }).then(response => response.json()).then(data => {
+    document.getElementById('response').innerText = JSON.stringify(data, null, 2);
+  });
 });
 </script>
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 from fastapi.testclient import TestClient
 from main import app, UrlInput, scrape_url, extract_info_with_chatgpt, split_html_content
 import os
@@ -16,28 +16,31 @@ class TestMain(unittest.TestCase):
         self.assertIsInstance(response.context, dict)
         self.assertIn('request', response.context)
 
-    def test_input_url(self):
+    @patch('main.scrape_url', return_value='<html><body>Mocked HTML content</body></html>')
+    @patch('main.extract_info_with_chatgpt', return_value='Mocked extracted info')
+    def test_input_url(self, mock_extract_info_with_chatgpt, mock_scrape_url):
         mock_url = 'http://mocked.url'
         mock_extracted_info = 'Mocked extracted info'
         mock_response = {'message': 'URL received', 'url': mock_url, 'extracted_info': mock_extracted_info}
-        self.client.post = Mock(return_value=Mock(status_code=200, json=lambda: mock_response))
         response = self.client.post('/input_url', json={'url': mock_url})
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), mock_response)
+        mock_scrape_url.assert_called_once_with(mock_url)
+        mock_extract_info_with_chatgpt.assert_called_once()
 
-    def test_scrape_url(self):
+    @patch('main.scrape_url', return_value='<html><body>Mocked HTML content</body></html>')
+    def test_scrape_url(self, mock_scrape_url):
         mock_url = 'http://mocked.url'
         mock_html_content = '<html><body>Mocked HTML content</body></html>'
-        scrape_url = Mock(return_value=mock_html_content)
-        self.assertEqual(scrape_url(mock_url), mock_html_content)
+        self.assertEqual(mock_scrape_url(mock_url), mock_html_content)
 
     def test_split_html_content(self):
         mock_html_content = 'a' * 900000
         expected_result = ['a' * 300000, 'a' * 300000, 'a' * 300000]
         self.assertEqual(split_html_content(mock_html_content), expected_result)
 
-    def test_extract_info_with_chatgpt(self):
+    @patch('main.extract_info_with_chatgpt', return_value='Mocked extracted info')
+    def test_extract_info_with_chatgpt(self, mock_extract_info_with_chatgpt):
         mock_html_content_list = ['<html><body>Mocked HTML content</body></html>', '<html><body>Another mocked HTML content</body></html>']
         mock_extracted_info = 'Mocked extracted info'
-        extract_info_with_chatgpt = Mock(return_value=mock_extracted_info)
-        self.assertEqual(extract_info_with_chatgpt(mock_html_content_list), mock_extracted_info)
+        self.assertEqual(mock_extract_info_with_chatgpt(mock_html_content_list), mock_extracted_info)


### PR DESCRIPTION
This PR addresses ticket JOH-31. Instead of printing the scraping URL in the console, it is now rendered in HTML below the form. A new div element has been added to the index.html file to display the response. The JavaScript fetch function has been updated to insert the response into this div.

### Test Plan

pytest